### PR TITLE
Update branch alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
   },
   "extra":{
     "branch-alias": {
-      "dev-master": "0.2.1-dev"
+      "dev-master": "1.0-dev"
     }
   },
   "autoload": {


### PR DESCRIPTION
It is common to point the branch alias to the next major or minor version before it it released. It can be used as a "beta" version until the stable version is released.

https://getcomposer.org/doc/articles/aliases.md

This way users can install version `^1.0` if they set `minimum-stability` to `dev` in their `composer.json` file.